### PR TITLE
Exposing fanMinOnTime setting

### DIFF
--- a/src/I_Ecobee1.xml
+++ b/src/I_Ecobee1.xml
@@ -1221,6 +1221,15 @@ decompress_lzo_file() {
     </action>
     <action>
       <serviceId>urn:ecobee-com:serviceId:Ecobee1</serviceId>
+      <name>SetFanMinOnTime</name>
+      <run>
+        local session = loadSession()
+        local selection = getSelection(session, lul_device)
+        return updateThermostats(session, ecobee.thermostatsUpdateOptions(selection, nil, { settings = { fanMinOnTime = lul_settings.MinOnTime } }));
+      </run>
+    </action>
+    <action>
+      <serviceId>urn:ecobee-com:serviceId:Ecobee1</serviceId>
       <name>ResumeProgram</name>
       <run>
         local session = loadSession()

--- a/src/S_Ecobee1.xml
+++ b/src/S_Ecobee1.xml
@@ -5,31 +5,26 @@
     <minor>0</minor>
   </specVersion>
   <serviceStateTable>
-    <stateVariable>
+    <stateVariable sendEvents="yes">
       <name>currentClimateRef</name>
       <dataType>string</dataType>
-      <sendEventsAttribute>yes</sendEventsAttribute>
     </stateVariable>
-    <stateVariable>
+    <stateVariable sendEvents="yes">
       <name>HumidityModeState</name>
       <dataType>string</dataType>
-      <sendEventsAttribute>yes</sendEventsAttribute>
     </stateVariable>
-    <stateVariable>
+    <stateVariable sendEvents="yes">
       <name>MessageTextVar</name>
       <dataType>string</dataType>
-      <sendEventsAttribute>yes</sendEventsAttribute>
     </stateVariable>
-    <stateVariable>
+    <stateVariable sendEvents="yes">
       <name>HoldClimateRefVar</name>
       <dataType>string</dataType>
-      <sendEventsAttribute>yes</sendEventsAttribute>
     </stateVariable>
-    <stateVariable>
+    <stateVariable sendEvents="yes">
       <name>MinOnTimeVar</name>
       <dataType>i4</dataType>
       <defaultValue>0</defaultValue>
-      <sendEventsAttribute>yes</sendEventsAttribute>
     </stateVariable>
   </serviceStateTable>
   <actionList>

--- a/src/S_Ecobee1.xml
+++ b/src/S_Ecobee1.xml
@@ -15,6 +15,12 @@
       <dataType>string</dataType>
       <sendEventsAttribute>yes</sendEventsAttribute>
     </stateVariable>
+    <stateVariable>
+      <name>FanMinOnTime</name>
+      <dataType>i4</dataType>
+      <defaultValue>0</defaultValue>
+      <sendEventsAttribute>yes</sendEventsAttribute>
+    </stateVariable>
   </serviceStateTable>
   <actionList>
     <action>
@@ -40,6 +46,16 @@
         <argument>
           <name>HoldClimateRef</name>
           <direction>in</direction>
+        </argument>
+      </argumentList>
+    </action>
+    <action>
+      <name>SetFanMinOnTime</name>
+      <argumentList>
+        <argument>
+          <name>MinOnTime</name>
+          <direction>in</direction>
+          <relatedStateVariable>FanMinOnTime</relatedStateVariable>
         </argument>
       </argumentList>
     </action>

--- a/src/S_Ecobee1.xml
+++ b/src/S_Ecobee1.xml
@@ -16,7 +16,17 @@
       <sendEventsAttribute>yes</sendEventsAttribute>
     </stateVariable>
     <stateVariable>
-      <name>FanMinOnTime</name>
+      <name>MessageTextVar</name>
+      <dataType>string</dataType>
+      <sendEventsAttribute>yes</sendEventsAttribute>
+    </stateVariable>
+    <stateVariable>
+      <name>HoldClimateRefVar</name>
+      <dataType>string</dataType>
+      <sendEventsAttribute>yes</sendEventsAttribute>
+    </stateVariable>
+    <stateVariable>
+      <name>MinOnTimeVar</name>
       <dataType>i4</dataType>
       <defaultValue>0</defaultValue>
       <sendEventsAttribute>yes</sendEventsAttribute>
@@ -37,6 +47,7 @@
         <argument>
           <name>MessageText</name>
           <direction>in</direction>
+          <relatedStateVariable>MessageTextVar</relatedStateVariable>
         </argument>
       </argumentList>
     </action>
@@ -46,6 +57,7 @@
         <argument>
           <name>HoldClimateRef</name>
           <direction>in</direction>
+          <relatedStateVariable>HoldClimateRefVar</relatedStateVariable>
         </argument>
       </argumentList>
     </action>
@@ -55,7 +67,7 @@
         <argument>
           <name>MinOnTime</name>
           <direction>in</direction>
-          <relatedStateVariable>FanMinOnTime</relatedStateVariable>
+          <relatedStateVariable>MinOnTimeVar</relatedStateVariable>
         </argument>
       </argumentList>
     </action>


### PR DESCRIPTION
Hello,

Thanks for all the work you've put into this plugin. I've been using it for a while and always wished it supported the fanMinOnTime setting. Today I finally looked at ecobee's API and saw that it was exposed and decided to get it done :)

I added the action to I_Ecobee1.xml and the ability to use it in a scene in S_Ecobee1.xml.

Usages:

```
luup.call_action("urn:ecobee-com:serviceId:Ecobee1", "SetFanMinOnTime", {["MinOnTime"] = "{number between 0 and 60}"}, {deviceNumber})

http://{veraip}:3480/data_request?id=action&output_format=xml&DeviceNum={deviceNumber}&serviceId=urn:ecobee-com:serviceId:Ecobee1&action=SetFanMinOnTime&MinOnTime={number between 0 and 60}
```

This is my first time modifying a vera plugin... Let me know if there are any changes I should make for you to consider adding it to the main repo.
